### PR TITLE
Fix: Ensure Reddit-style dark theme is applied by default

### DIFF
--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -29,9 +29,13 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
   const [theme, setTheme] = useState<Theme>('dark');
 
   useEffect(() => {
-    const savedTheme = localStorage.getItem('theme') as Theme;
-    if (savedTheme) {
-      setTheme(savedTheme);
+    const savedTheme = localStorage.getItem('theme');
+    // Explicitly set to 'dark' if savedTheme is not 'light'.
+    // This makes 'dark' the strong default.
+    if (savedTheme === 'light') {
+      setTheme('light');
+    } else {
+      setTheme('dark');
     }
   }, []);
 


### PR DESCRIPTION
The UI was not consistently updating to the discussed Reddit-style appearance. This was likely due to the theme defaulting to or being stuck on the light theme.

This commit modifies `ThemeProvider.tsx` to make the 'dark' theme the robust default. If no theme is explicitly set to 'light' in localStorage, the application will now consistently use the 'dark' theme settings defined in `index.css` and referenced by Tailwind CSS.

This ensures that the intended Reddit-style dark background, card colors, and other visual elements are active upon loading the application, resolving the UI update issue.